### PR TITLE
Changing tmp dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,11 +20,21 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+# Configure Jenkins init settings.
+# pre-requisite: create $JENKINS_HOME/tmp
+- name: create new tmp dir
+  file:
+    path: /var/lib/jenkins/tmp
+    owner: jenkins
+    group: jenkins
+    mode: 0755
+    state: directory
+
+- include: settings.yml
+
+# Enable and start jenkins
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes
-
-# Configure Jenkins init settings.
-- include: settings.yml
 
 # Initialize default admin user(s)
 - name: check if admin users are defined

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -7,6 +7,12 @@
     line: 'JENKINS_ARGS="$JENKINS_ARGS --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_prefix
 
+- name: modify jenkins defaults to change tmp directory
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    line: 'JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS -Djava.io.tmpdir=$JENKINS_HOME/tmp "'
+  register: jenkins_init_tmpdir_fix
+
 - name: modify jenkins defaults to fix cli calls
   lineinfile:
     dest: "{{ jenkins_init_file }}"
@@ -45,6 +51,7 @@
   service: name=jenkins state=restarted
   when: >
     jenkins_init_prefix.changed or
+    jenkins_init_tmpdir_fix.changed or
     jenkins_init_cli_fix.changed or
     jenkins_init_crumb_issuer.changed or
     jenkins_init_csp_fix.changed or


### PR DESCRIPTION
`/tmp` will normally have `noexec` enabled. This gets around that.